### PR TITLE
Add no-restricted-imports rule for general lodash imports

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -128,6 +128,10 @@ module.exports = {
     'no-process-env': 'error',
     'no-process-exit': 'error',
     'no-proto': 'error',
+    'no-restricted-imports': ['error', {
+      message: 'Please import individual modules from \'lodash/*\' instead.',
+      name: 'lodash'
+    }],
     'no-restricted-modules': 'error',
     'no-return-assign': 'error',
     'no-script-url': 'error',

--- a/test/fixtures/correct.js
+++ b/test/fixtures/correct.js
@@ -291,12 +291,13 @@ for (let semiSpacing = 0; semiSpacing < 10; ++semiSpacing) {
   noop();
 }
 
-// `sort-imports`.
+// `sort-imports` and `no-rescrited-imports`.
 import 'import-1';
 import * as Import6 from 'import-2';
 import { Import5, import4 } from 'import-3';
 import { import3 } from 'import-4';
 import Import2 from 'import-5';
+import get from 'lodash/get';
 import import1 from 'import-6';
 
 noop(Import2);
@@ -305,6 +306,7 @@ noop(Import6);
 noop(import1);
 noop(import3);
 noop(import4);
+noop(get);
 
 // `sort-keys`.
 const sortObjectProps = {

--- a/test/fixtures/incorrect.js
+++ b/test/fixtures/incorrect.js
@@ -289,12 +289,14 @@ for (let semiSpacing = 0; semiSpacing < 10; ++semiSpacing) {
   noop();
 }
 
-// `sort-imports`.
+// `sort-imports` and `no-rescrited-imports`.
 import import1 from 'import-1';
+import { get } from 'lodash';
 import { import2 } from 'import-2';
 
 noop(import1);
 noop(import2);
+noop(get);
 
 // `sort-keys`.
 const sortObjectProps = {

--- a/test/index.js
+++ b/test/index.js
@@ -65,6 +65,7 @@ describe('eslint-config-untile', () => {
       'no-undef',
       'no-underscore-dangle',
       'no-unused-vars',
+      'no-restricted-imports',
       'sort-imports-es6/sort-imports-es6',
       'sort-keys',
       'sql-template/no-unsafe-query'


### PR DESCRIPTION
This PR adds `no-restricted-imports` rule for general lodash imports.

### Good
```js
import get from 'lodash/get';
```

### Bad
```js
import { get } from 'lodash';
```