### PR TITLE
Migrate publish to npm

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -17,17 +17,17 @@ jobs:
 
       - name: Checkout code
         uses: actions/checkout@v2
-      
+
       - name: Setup node
         uses: actions/setup-node@v2
         with:
-          node-version: '14'
-          registry-url: 'https://npm.pkg.github.com'
-      
+          node-version: "14"
+          registry-url: https://registry.npmjs.org/
+
       - name: Install module dependencies
         run: yarn
-      
+
       - name: Publish
-        run: yarn publish
+        run: npm publish --access public
         env:
-          NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+ssh://git@github.com/untile/eslint-config-untile.git"
+    "url": "https://github.com/untile/eslint-config-untile.git"
   },
   "license": "MIT",
   "author": "Untile",


### PR DESCRIPTION
This PR updates the `publish` workflow to be done by npm and not for github.